### PR TITLE
#1077 - Group and its children are hidden after being grouped again

### DIFF
--- a/jsapp/xlform_model_view/view.rowSelector.coffee
+++ b/jsapp/xlform_model_view/view.rowSelector.coffee
@@ -15,7 +15,6 @@ define 'cs!xlform/view.rowSelector', [
   class viewRowSelector.RowSelector extends $baseView
     events:
       "click .js-close-row-selector": "shrink"
-      "submit .row__questiontypes__form": "show_picker"
     initialize: (opts)->
       @options = opts
       @ngScope = opts.ngScope
@@ -27,6 +26,11 @@ define 'cs!xlform/view.rowSelector', [
 
     expand: ->
       @show_namer()
+      $namer_form = @$el.find('.row__questiontypes__form')
+      $namer_form.on 'submit', _.bind @show_picker, @
+      $namer_form.find('button').on 'click', (evt) ->
+        evt.preventDefault()
+        $namer_form.submit()
       @$('input').eq(0).focus()
 
     show_namer: () ->

--- a/jsapp/xlform_model_view/view.surveyApp.coffee
+++ b/jsapp/xlform_model_view/view.surveyApp.coffee
@@ -198,9 +198,9 @@ define 'cs!xlform/view.surveyApp', [
 
         $target.toggleClass("survey__row--selected")
         if $target.hasClass('survey__row--group')
-          $target.find('li').toggleClass("survey__row--selected", $target.hasClass("survey__row--selected"))
+          $target.find('li.survey__row, li.survey__row--group').toggleClass("survey__row--selected", $target.hasClass("survey__row--selected"))
 
-        $group = $target.parents('.survey__row')
+        $group = $target.parent().closest('.survey__row')
         if $group.length > 0
           @select_group_if_all_items_selected($group)
 
@@ -210,9 +210,12 @@ define 'cs!xlform/view.surveyApp', [
     select_group_if_all_items_selected: ($group) ->
       $rows = $group.find('.survey__row')
       $group.toggleClass('survey__row--selected', $rows.length == $rows.filter('.survey__row--selected').length)
+      $group = $group.parent().closest('.survey__row')
+      if $group.length > 0
+        @select_group_if_all_items_selected($group)
 
     questionSelect: (evt)->
-      @activateGroupButton(@selectedRows().length > 0)
+      @activateGroupButton(@$el.find('.survey__row--selected').length > 0)
       return
 
     activateGroupButton: (active=true)->
@@ -538,6 +541,8 @@ define 'cs!xlform/view.surveyApp', [
       rows = []
       @$el.find('.survey__row--selected').each (i, el)=>
         $el = $(el)
+        if $el.parents('li.survey__row--group.survey__row--selected').length > 0
+          return
         rowId = $el.data("rowId")
         matchingRow = false
         findMatch = (row)->


### PR DESCRIPTION
also fixes issue when grouping nested groups that removes inner items from group and correctly selecting parent groups when all inner items are selected
