### PR TITLE
wrapping KC post and returning a clean error message on failure

### DIFF
--- a/dkobo/koboform/views/survey_draft_views.py
+++ b/dkobo/koboform/views/survey_draft_views.py
@@ -213,7 +213,7 @@ def publish_survey_draft(request, pk, format=None):
         status_code = response.status_code
         resp = response.json()
     except Exception, e:
-        resp = json.dumps({'status_code': 504, 'detail': 'There was an error while publishing your survey'})
+        resp = json.dumps({'status_code': 504, 'detail': 'There was an error while publishing your survey: %s' % e.message})
         status_code = 504
 
     if 'formid' in resp:


### PR DESCRIPTION
tp #1472 can't be reproduced locally so hopefully this will give more info to us and to the user
