### PR TITLE
Add django_digest to INSTALLED_APPS to generate password digests for API authentication

### DIFF
--- a/dkobo/settings.py
+++ b/dkobo/settings.py
@@ -109,6 +109,7 @@ INSTALLED_APPS = (
     'rest_framework.authtoken',
     'django_extensions',
     'taggit',
+    'django_digest',
 )
 
 SOUTH_MIGRATION_MODULES = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,8 @@ django-markitup==2.2.2
 jsonfield==0.9.20
 django-taggit
 -e git+https://github.com/kobotoolbox/pyxform.git@koboform-stable#egg=pyxform-dev
+
+# match kobocat's version of django-digest
+django-digest==1.13
+# django-digest depends on python-digest but does not install it automatically
+python-digest==1.7


### PR DESCRIPTION
Without having the `django_digest` app in the project that handles authentication (this project!), the `django_digest_partialdigest` table doesn't get populated. These overrides from [django-digest's models.py](https://bitbucket.org/akoha/django-digest/src/fe72787e860ed42c8ff3ee8edd17b24225fa06f5/django_digest/models.py?at=default#cl-113) have to be in place:

```
User.check_password = _new_check_password    
User.set_password = _new_set_password
ModelBackend.authenticate = _new_authenticate
```

Otherwise, [`onadata.libs.authentication.DigestAuthentication.authenticate()`](https://github.com/kobotoolbox/kobocat/blob/master/onadata/libs/authentication.py#L18) fails due to "no partial digest available for user"--a message that can only be seen if django-digest logging is set to DEBUG.
