### PR TITLE
Fix some Karma test failures

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,12 +69,12 @@ module.exports = function(grunt) {
                 browsers: ['PhantomJS'],
             },
             amd: {
+                /** It would be better to prevent the second karma server from
+                 *  starting altogether, instead of just changing the port,
+                 *  but that seems unattainable with multiple configuration files.
+                 */
+                port: 9877,
                 configFile: 'jsapp/test/configs/karma-amd.conf.js',
-                singleRun: true,
-                browsers: ['PhantomJS'],
-            },
-            travis: {
-                configFile: 'jsapp/test/configs/karma.conf.js',
                 singleRun: true,
                 browsers: ['PhantomJS'],
             },

--- a/jsapp/test/configs/karma-amd.conf.js
+++ b/jsapp/test/configs/karma-amd.conf.js
@@ -70,7 +70,7 @@ module.exports = function(config) {
         autoWatch: false,
         browsers: ['PhantomJS'],
         captureTimeout: 60000,
-        browserNoActivityTimeout: 20000,
+        browserNoActivityTimeout: 60000,
         singleRun: true,
     });
 };


### PR DESCRIPTION
A PhantomJS timeout was causing Travis builds to fail. Two Karma servers are starting, which is a waste, but I squelched a warning by moving the second server to a non-conflicting port.