### PR TITLE
TypeError fixed  + djangorest upgraded

### DIFF
--- a/dkobo/koboform/kobocat_integration/__init__.py
+++ b/dkobo/koboform/kobocat_integration/__init__.py
@@ -28,9 +28,9 @@ def _is_enabled():
 
 def _kobocat_url(path="/", query_string=False, internal=False):
     if internal:
-        prepped_url = settings.KOBOCAT_INTERNAL_URL
+        prepped_url = "" if isinstance(settings.KOBOCAT_INTERNAL_URL, bool) else settings.KOBOCAT_INTERNAL_URL
     else:
-        prepped_url = settings.KOBOCAT_URL
+        prepped_url = "" if isinstance(settings.KOBOCAT_URL, bool) else settings.KOBOCAT_URL
 
     prepped_url += path
 

--- a/jsapp/kobo/directives/InfoList.Directive.js
+++ b/jsapp/kobo/directives/InfoList.Directive.js
@@ -38,7 +38,8 @@ kobo.directive ('infoList', function ($rootScope, $miscUtils, $location) {
             scope.itemError = function (item) {
                 if (!item._summary) {
                     try {
-                        item._summary = JSON.parse(item.summary);
+//                        item._summary = JSON.parse(item.summary);
+                        item._summary = item.summary;
                     } catch (e) {
                         item._summary = {};
                     }

--- a/jsapp/kobo/directives/KobocatFormPublisher.Directive.js
+++ b/jsapp/kobo/directives/KobocatFormPublisher.Directive.js
@@ -43,7 +43,8 @@ kobo.directive ('kobocatFormPublisher', ['$api', '$miscUtils', '$routeTo', funct
 
             scope.show_form_name_exists_message = false;
             scope.get_form_id = function (item) {
-                return JSON.parse(item.summary).form_id;
+//                return JSON.parse(item.summary).form_id;
+                return item.summary.form_id;
             };
             scope.form_name = scope.get_form_id(scope.item);
 

--- a/jsapp/kobo/factories/restApi.Factory.js
+++ b/jsapp/kobo/factories/restApi.Factory.js
@@ -191,7 +191,8 @@ kobo.factory('$restApi', ['$resource', '$timeout', '$cacheFactory', '$rootScope'
                 }
 
                 function get_props_from_row(item) {
-                    var summary = JSON.parse(item.summary);
+//                    var summary = JSON.parse(item.summary);
+                    var summary = item.summary;
                     item.type = summary.type;
                     item.label = summary.label;
                     item.responses = summary.options;

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.6
 django-compressor==1.4
 django-toolbelt==0.0.1
 hamlpy==0.82.2
-South==0.8.4
+South==1.0.2
 gunicorn==18.0
 BeautifulSoup==3.2.1
 django-registration==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ South==0.8.4
 gunicorn==18.0
 BeautifulSoup==3.2.1
 django-registration==1.0
-djangorestframework==2.3.10
+djangorestframework==2.4.3
 xlwt==0.7.5
 django-extensions==1.3.3
 manifesto==0.5


### PR DESCRIPTION
Hi, 

1- I fixed the **TypeError (unsupported operand type(s) for +=: 'bool' and 'str')** appearing when **settings.KOBOCAT_URL** is not set (=False)

2- I tryed to mingle **dkobo** and **kobocat** in the same environment. I found out that i needed to upgrade djangorestframework to 2.4.3.