### PR TITLE
Use a post_save User signal to grant permissions that KC would have

### DIFF
--- a/dkobo/koboform/__init__.py
+++ b/dkobo/koboform/__init__.py
@@ -1,0 +1,1 @@
+import signals

--- a/dkobo/koboform/signals.py
+++ b/dkobo/koboform/signals.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from django.contrib.auth.models import User, Permission
+from django.db.models.signals import post_save
+
+def set_model_level_permissions(sender, instance, created, raw, **kwargs):
+    ''' Mirror KoBoCAT's set_api_permissions_for_user; see
+    https://github.com/kobotoolbox/kobocat/blob/master/onadata/libs/utils/user_auth.py
+    '''
+    if raw or not created:
+        # Only apply permissions at creation; we aren't allowed to touch raw
+        # saves
+        return
+    for app_label, model in settings.KOBOCAT_DEFAULT_PERMISSION_CONTENT_TYPES:
+        for permission in Permission.objects.filter(
+                content_type__app_label=app_label,
+                content_type__model=model):
+            # We open the model-level permissions wide, allowing
+            # django-guardian's object-level pwrmissions to serve as the
+            # real gatekeepers
+            instance.user_permissions.add(permission)
+
+post_save.connect(set_model_level_permissions, sender=User)

--- a/dkobo/koboform/views/survey_draft_views.py
+++ b/dkobo/koboform/views/survey_draft_views.py
@@ -1,7 +1,6 @@
 import json
 import requests
 import pyxform.survey_from
-from guardian.shortcuts import assign_perm
 
 from django.http import HttpResponseBadRequest, HttpResponse, HttpResponseRedirect
 from django.conf import settings
@@ -236,7 +235,6 @@ def publish_survey_draft(request, pk, format=None):
     # convert kobo-specific data structures into valid xlsform (e.g. score, rank)
     xlsform_ss_struct = convert_any_kobo_features_to_xlsform_survey_structure(ss_struct)
     valid_xlsform_csv_repr = pyxform_utils.convert_ss_structure_to_csv(xlsform_ss_struct)
-    _set_necessary_permissions(request.user)
     (token, is_new) = Token.objects.get_or_create(user=request.user)
     headers = {u'Authorization':'Token ' + token.key}
 
@@ -260,18 +258,6 @@ def publish_survey_draft(request, pk, format=None):
             })
 
     return Response(resp, status=status_code)
-
-def _set_necessary_permissions(user):
-    """
-    defeats the point of permissions, yes. But might get things working for now until we understand
-    the way kobocat uses permissions.
-    """
-    necessary_perms = {'logger': ['add_datadictionary', 'add_xform', 'change_datadictionary', \
-                                    'change_xform', 'delete_datadictionary', 'delete_xform', \
-                                    'report_xform', 'view_xform',]}
-    for app, perms in necessary_perms.items():
-        for perm in perms:
-            assign_perm('%s.%s' % (app, perm), user)
 
 def published_survey_draft_url(request, pk):
     try:

--- a/dkobo/settings.py
+++ b/dkobo/settings.py
@@ -129,6 +129,24 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 KOBOCAT_URL = os.environ.get('KOBOCAT_URL')
 KOBOCAT_INTERNAL_URL = os.environ.get('KOBOCAT_INTERNAL_URL', KOBOCAT_URL)
 
+''' Since this project handles user creation but shares its database with
+KoBoCAT, we must handle the model-level permission assignment that would've
+been done by KoBoCAT's post_save signal handler. Here we record the content
+types of the models listed in KC's set_api_permissions_for_user(). Verify that
+this list still matches that function if you experience permission-related
+problems. See
+https://github.com/kobotoolbox/kobocat/blob/master/onadata/libs/utils/user_auth.py.
+'''
+KOBOCAT_DEFAULT_PERMISSION_CONTENT_TYPES = [
+    #(app_label, model)
+    ('main', 'userprofile'),
+    ('logger', 'xform'),
+    ('api', 'project'),
+    ('api', 'team'),
+    ('api', 'organizationprofile'),
+   ('logger', 'note'),
+]
+
 # The number of surveys to import. -1 is all
 KOBO_SURVEY_IMPORT_COUNT = os.environ.get('KOBO_SURVEY_IMPORT_COUNT', 100)
 

--- a/dkobo/settings.py
+++ b/dkobo/settings.py
@@ -144,7 +144,7 @@ KOBOCAT_DEFAULT_PERMISSION_CONTENT_TYPES = [
     ('api', 'project'),
     ('api', 'team'),
     ('api', 'organizationprofile'),
-   ('logger', 'note'),
+    ('logger', 'note'),
 ]
 
 # The number of surveys to import. -1 is all


### PR DESCRIPTION
KC's post_save handler never gets called for new users since they're always created by KF. Have KF mirror KC's post_save behavior and grant permissive model-level access.