### PR TITLE
Fix Skip Logic message for Groups

### DIFF
--- a/jsapp/xlform_model_view/mv.skipLogicHelpers.coffee
+++ b/jsapp/xlform_model_view/mv.skipLogicHelpers.coffee
@@ -17,7 +17,7 @@ define 'cs!xlform/mv.skipLogicHelpers', [
     create_builder: () ->
       return new skipLogicHelpers.SkipLogicBuilder @model_factory, @view_factory, @survey, @current_question, @
     create_context: () ->
-      return new skipLogicHelpers.SkipLogicHelperContext @model_factory, @view_factory, @, @serialized_criteria
+      return new skipLogicHelpers.SkipLogicHelperContext @model_factory, @view_factory, @, @current_question, @serialized_criteria
 
   ###----------------------------------------------------------------------------------------------------------###
   #-- Facades.RowDetail.coffee
@@ -277,7 +277,7 @@ define 'cs!xlform/mv.skipLogicHelpers', [
       @state = new skipLogicHelpers.SkipLogicModeSelectorHelper(@view_factory, @)
       @render @destination
       return
-    constructor: (@model_factory, @view_factory, @helper_factory, serialized_criteria) ->
+    constructor: (@model_factory, @view_factory, @helper_factory, @current_question, serialized_criteria) ->
       @state = serialize: () -> return serialized_criteria
       if !serialized_criteria? || serialized_criteria == ''
         serialized_criteria = ''
@@ -341,7 +341,7 @@ define 'cs!xlform/mv.skipLogicHelpers', [
         trackJs?.console.error("@$add_new_criterion_button is not defined. cannot call #{action} [inside of determine_add_new_criterion_visibility]")
 
     constructor: (@presenters, separator, @builder, @view_factory, @context) ->
-      @view = @view_factory.create_criterion_builder_view()
+      @view = @view_factory.create_criterion_builder_view(@context.current_question)
       @view.criterion_delimiter = (separator || 'and').toLowerCase()
       @view.facade = @
       @dispatcher = _.clone Backbone.Events

--- a/jsapp/xlform_model_view/mv.validationLogicHelpers.coffee
+++ b/jsapp/xlform_model_view/mv.validationLogicHelpers.coffee
@@ -11,7 +11,7 @@ define 'cs!xlform/mv.validationLogicHelpers', [
     create_builder: () ->
       return new validationLogicHelpers.ValidationLogicBuilder @model_factory, @view_factory, @survey, @current_question, @
     create_context: () ->
-      return new validationLogicHelpers.ValidationLogicHelperContext @model_factory, @view_factory, @, @serialized_criteria
+      return new validationLogicHelpers.ValidationLogicHelperContext @model_factory, @view_factory, @, @current_question, @serialized_criteria
 
   class validationLogicHelpers.ValidationLogicPresenter extends $skipLogicHelpers.SkipLogicPresenter
     change_question: () -> return
@@ -53,7 +53,7 @@ define 'cs!xlform/mv.validationLogicHelpers', [
         @state.button = @view_factory.create_empty()
       @render @destination
       return
-    constructor: (@model_factory, @view_factory, @helper_factory, serialized_criteria) ->
+    constructor: (@model_factory, @view_factory, @helper_factory, @current_question, serialized_criteria) ->
       @state = serialize: () -> return serialized_criteria
       if @questionTypeHasNoValidationOperators()
         @use_hand_code_helper()

--- a/jsapp/xlform_model_view/view.rowDetail.SkipLogic.coffee
+++ b/jsapp/xlform_model_view/view.rowDetail.SkipLogic.coffee
@@ -17,15 +17,20 @@ define 'cs!xlform/view.rowDetail.SkipLogic', [
   ###----------------------------------------------------------------------------------------------------------###
 
   class viewRowDetailSkipLogic.SkipLogicCriterionBuilderView extends $viewWidgets.Base
+    constructor: (@rowkls = "Row", options = {}) ->
+      super(options)
     events:
       "click .skiplogic__deletecriterion": "deleteCriterion"
       "click .skiplogic__addcriterion": "addCriterion"
       "change .skiplogic__delimselect": "markChangedDelimSelector"
     render: () ->
       tempId = _.uniqueId("skiplogic_expr")
+      message = if @rowkls is "Group" \
+        then "This group will only be displayed if the following conditions apply:" \
+        else "This question will only be displayed if the following conditions apply:"
       @$el.html("""
         <p>
-          This question will only be displayed if the following conditions apply
+          #{message}
         </p>
         <div class="skiplogic__criterialist"></div>
         <p class="skiplogic__addnew">
@@ -313,8 +318,8 @@ define 'cs!xlform/view.rowDetail.SkipLogic', [
         else null
     create_criterion_view: (question_picker_view, operator_picker_view, response_value_view, presenter) ->
       return new viewRowDetailSkipLogic.SkipLogicCriterion question_picker_view, operator_picker_view, response_value_view, presenter
-    create_criterion_builder_view: () ->
-      return new viewRowDetailSkipLogic.SkipLogicCriterionBuilderView()
+    create_criterion_builder_view: (target_question) ->
+      return new viewRowDetailSkipLogic.SkipLogicCriterionBuilderView(target_question.constructor.kls)
     create_textarea: (text, className) ->
       return new $viewWidgets.TextArea text, className
     create_button: (text, className) ->


### PR DESCRIPTION
Click 'Add a condition' button on a group's skip logic settings, and it'll show 'This group will only be displayed' instead of 'This question will only be displayed...'