### PR TITLE
Redirect to other builder by prefix; new library route

### DIFF
--- a/dkobo/hub/middleware.py
+++ b/dkobo/hub/middleware.py
@@ -7,28 +7,36 @@ class OtherFormBuilderRedirectMiddleware(object):
     If the user prefers to use another form builder, redirect to it
     '''
     THIS_BUILDER = FormBuilderPreference.DKOBO
-    PREFERENCE_TO_URL = {
-        FormBuilderPreference.KPI: settings.KPI_URL,
-        FormBuilderPreference.DKOBO: settings.DKOBO_URL,
+    PREFERENCE_TO_PREFIX = {
+        FormBuilderPreference.KPI: settings.KPI_PREFIX,
+        FormBuilderPreference.DKOBO: settings.DKOBO_PREFIX,
     }
 
     def _redirect_if_necessary(self, request, preferred_builder):
         try:
-            preferred_url = self.PREFERENCE_TO_URL[preferred_builder]
+            preferred_prefix = self.PREFERENCE_TO_PREFIX[preferred_builder]
         except KeyError:
             # Ignore invalid preference
             return
-        if not request.build_absolute_uri().startswith(preferred_url):
-            return HttpResponseRedirect(preferred_url)
+        prefix_length = max(1, len(request.path) - len(request.path_info))
+        prefix = request.path[:prefix_length]
+        if prefix != preferred_prefix:
+            try:
+                # Requires Django 1.7
+                scheme = request.scheme
+            except:
+                scheme = 'https' if request.is_secure() else 'http'
+            return HttpResponseRedirect(u'{}://{}{}'.format(
+                scheme, request.get_host(), preferred_prefix))
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         ''' Using process_view instead of process_request allows the resolver
         to run and return 404 when appropriate, instead of blindly returning
         302 for all requests '''
         preferred_builder = self.THIS_BUILDER
-        if not settings.KPI_URL or not settings.DKOBO_URL \
+        if not settings.KPI_PREFIX or not settings.DKOBO_PREFIX \
                 or request.user.is_anonymous():
-            # Do not attempt to redirect if the necessary URLs are not
+            # Do not attempt to redirect if the necessary prefixes are not
             # configured or the user is anonymous
             return
         try:
@@ -36,5 +44,5 @@ class OtherFormBuilderRedirectMiddleware(object):
                 request.user.formbuilderpreference.preferred_builder
         except FormBuilderPreference.DoesNotExist:
             # Ignore missing preference
-            pass    
+            pass
         return self._redirect_if_necessary(request, preferred_builder)

--- a/dkobo/settings.py
+++ b/dkobo/settings.py
@@ -129,7 +129,9 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 KOBOCAT_URL = os.environ.get('KOBOCAT_URL')
 KOBOCAT_INTERNAL_URL = os.environ.get('KOBOCAT_INTERNAL_URL', KOBOCAT_URL)
 
-KPI_URL = os.environ.get('KPI_URL', False)
+# Following the uWSGI mountpoint convention, this should have a leading slash
+# but no trailing slash
+KPI_PREFIX = os.environ.get('KPI_PREFIX', False)
 
 ''' Since this project handles user creation but shares its database with other
 projects, we must handle the model-level permission assignment that would've
@@ -217,12 +219,14 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-# DKOBO_URL should be set in the environment when running in a subdirectory
-DKOBO_URL = os.environ.get('DKOBO_URL', False)
-if DKOBO_URL:
-    STATIC_URL = DKOBO_URL + STATIC_URL
+# Following the uWSGI mountpoint convention, this should have a leading slash
+# but no trailing slash
+DKOBO_PREFIX = os.environ.get('DKOBO_PREFIX', False)
+# DKOBO_PREFIX should be set in the environment when running in a subdirectory
+if DKOBO_PREFIX and DKOBO_PREFIX != '/':
+    STATIC_URL = '{}/{}'.format(DKOBO_PREFIX, STATIC_URL)
     from django.conf.global_settings import LOGIN_URL
-    LOGIN_URL = DKOBO_URL + LOGIN_URL
+    LOGIN_URL = '{}/{}'.format(DKOBO_PREFIX, LOGIN_URL)
 
 EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')

--- a/jsapp/kobo/app.js
+++ b/jsapp/kobo/app.js
@@ -71,6 +71,11 @@ kobo.config(function ($routeProvider, $locationProvider, $httpProvider) {
             controller: 'BuilderController'
         });
 
+        $routeProvider.when('/library', {
+            templateUrl: staticFilesUri + 'templates/QuestionLibrary.Template.html',
+            controller: 'AssetsController'
+        });
+
         $routeProvider.when('/library/questions', {
             templateUrl: staticFilesUri + 'templates/QuestionLibrary.Template.html',
             controller: 'AssetsController'


### PR DESCRIPTION
Requires new `KPI_PREFIX` and `DKOBO_PREFIX` environment variables