### PR TITLE
adding configurable ALLOWED_HOSTS setting

### DIFF
--- a/dkobo/settings.py
+++ b/dkobo/settings.py
@@ -192,7 +192,8 @@ DATABASES = {
     'default': dj_database_url.config(default="sqlite:///%s/db.sqlite3" % BASE_DIR)
 }
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', '*').split(' ')
+
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # For GeoDjango heroku buildpack


### PR DESCRIPTION
DJANGO_ALLOWED_HOSTS environment variable is a space-separated list
which is pulled into settings.

https://docs.djangoproject.com/en/1.8/ref/settings/#allowed-hosts