### PR TITLE
New admin action to delete users' related objects

### DIFF
--- a/dkobo/hub/actions.py
+++ b/dkobo/hub/actions.py
@@ -1,0 +1,107 @@
+"""
+Mostly copied from django/contrib/admin/actions.py
+"""
+
+from collections import OrderedDict
+from django.core.exceptions import PermissionDenied
+from django.contrib import messages
+from django.contrib.admin import helpers
+from django.contrib.admin.util import get_deleted_objects, model_ngettext
+from django.contrib.admin.util import NestedObjects
+from django.db import router, transaction
+from django.template.response import TemplateResponse
+from django.utils.encoding import force_text
+from django.utils.translation import ugettext_lazy, ugettext as _
+
+def delete_related_objects(modeladmin, request, queryset):
+    """
+    Action that deletes related objects for the selected items.
+
+    This action first displays a confirmation page whichs shows all the
+    deleteable objects, or, if the user has no permission one of the related
+    childs (foreignkeys), a "permission denied" message.
+
+    Next, it deletes all related objects and redirects back to the change list.
+    """
+    opts = modeladmin.model._meta
+    app_label = opts.app_label
+
+    # Check that the user has delete permission for the actual model
+    if not modeladmin.has_delete_permission(request):
+        raise PermissionDenied
+
+    using = router.db_for_write(modeladmin.model)
+
+    first_level_related_objects = []
+    collector = NestedObjects(using=using)
+    collector.collect(queryset)
+    for base_object_or_related_list in collector.nested():
+        if type(base_object_or_related_list) is not list:
+            # If it's not a list, it's a base object. Skip it.
+            continue
+        for obj in base_object_or_related_list:
+            if type(obj) is list:
+                # A list here contains related objects for the previous
+                # element. We can skip it since delete() on the first
+                # level of related objects will cascade.
+                continue
+            else:
+                first_level_related_objects.append(obj)
+
+    # Populate deletable_objects, a data structure of (string representations
+    # of) all related objects that will also be deleted.
+    deletable_objects, perms_needed, protected = get_deleted_objects(
+        first_level_related_objects, opts, request.user,
+        modeladmin.admin_site, using
+    )
+
+    # The user has already confirmed the deletion.
+    # Do the deletion and return a None to display the change list view again.
+    if request.POST.get('post'):
+        if perms_needed:
+            raise PermissionDenied
+        n = 0
+        with transaction.atomic(using):
+            for obj in first_level_related_objects:
+                obj_display = force_text(obj)
+                modeladmin.log_deletion(request, obj, obj_display)
+                obj.delete()
+                n += 1
+        modeladmin.message_user(
+            request,
+            _("Successfully deleted %(count)d related objects.") % {
+                "count": n, "items": model_ngettext(modeladmin.opts, n)},
+            messages.SUCCESS
+        )
+        # Return None to display the change list page again.
+        return None
+
+    if len(queryset) == 1:
+        objects_name = force_text(opts.verbose_name)
+    else:
+        objects_name = force_text(opts.verbose_name_plural)
+
+    if perms_needed or protected:
+        title = _("Cannot delete %(name)s") % {"name": objects_name}
+    else:
+        title = _("Are you sure?")
+
+    context = {
+        "title": title,
+        "objects_name": objects_name,
+        "deletable_objects": [deletable_objects] if deletable_objects else [],
+        'queryset': queryset,
+        "perms_lacking": perms_needed,
+        "protected": protected,
+        "opts": opts,
+        "app_label": app_label,
+        'action_checkbox_name': helpers.ACTION_CHECKBOX_NAME,
+    }
+
+    # Display the confirmation page
+    return TemplateResponse(
+        request, "delete_related_for_selected_confirmation.html",
+        context, current_app=modeladmin.admin_site.name)
+
+delete_related_objects.short_description = ugettext_lazy(
+    "Remove related objects for these %(verbose_name_plural)s")

--- a/dkobo/hub/admin.py
+++ b/dkobo/hub/admin.py
@@ -1,4 +1,12 @@
 from django.contrib import admin
-from dkobo.hub.models import SitewideMessage
+from django.contrib.auth.models import User
+from django.contrib.auth.admin import UserAdmin
+from models import SitewideMessage
+from actions import delete_related_objects
+
+class UserDeleteRelatedAdmin(UserAdmin):
+    actions = [delete_related_objects]
 
 admin.site.register(SitewideMessage)
+admin.site.unregister(User)
+admin.site.register(User, UserDeleteRelatedAdmin)

--- a/dkobo/hub/templates/delete_related_for_selected_confirmation.html
+++ b/dkobo/hub/templates/delete_related_for_selected_confirmation.html
@@ -1,0 +1,50 @@
+{# mostly copied from django/contrib/admin/templates/admin/delete_selected_confirmation.html #}
+{% extends "admin/base_site.html" %}
+{% load i18n l10n admin_urls %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=app_label %}">{{ app_label|capfirst|escape }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+&rsaquo; {% trans 'Delete related objects' %}
+</div>
+{% endblock %}
+
+{% block content %}
+{% if perms_lacking or protected %}
+    {% if perms_lacking %}
+        <p>{% blocktrans %}Your account doesn't have permission to delete the following types of objects:{% endblocktrans %}</p>
+        <ul>
+        {% for obj in perms_lacking %}
+            <li>{{ obj }}</li>
+        {% endfor %}
+        </ul>
+    {% endif %}
+    {% if protected %}
+        <p>{% blocktrans %}The following related objects are protected:{% endblocktrans %}</p>
+        <ul>
+        {% for obj in protected %}
+            <li>{{ obj }}</li>
+        {% endfor %}
+        </ul>
+    {% endif %}
+{% else %}
+    <p>{% blocktrans %}Are you sure you want to delete all of the following objects?{% endblocktrans %}</p>
+    {% for deletable_object in deletable_objects %}
+        <ul>{{ deletable_object|unordered_list }}</ul>
+    {% empty %}
+        <p>{% blocktrans %}There are no related objects to delete.{% endblocktrans %}</p>
+    {% endfor %}
+    <form action="" method="post">{% csrf_token %}
+    <div>
+    {% for obj in queryset %}
+    <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}" />
+    {% endfor %}
+    <input type="hidden" name="action" value="delete_related_objects" />
+    <input type="hidden" name="post" value="yes" />
+    <input type="submit" value="{% trans "Yes, I'm sure" %}" />
+    </div>
+    </form>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
Will allow other projects sharing the auth_users table to delete users; see
https://github.com/kobotoolbox/kobocat/issues/92