### PR TITLE
Consolidate Enketo settings across KoBo to `ENKETO_URL` and `ENKETO_V…

### DIFF
--- a/dkobo/settings.py
+++ b/dkobo/settings.py
@@ -161,8 +161,10 @@ KOBO_SURVEY_IMPORT_COUNT = os.environ.get('KOBO_SURVEY_IMPORT_COUNT', 100)
 KOBO_SURVEY_PREVIEW_EXPIRATION = os.environ.get('KOBO_SURVEY_PREVIEW_EXPIRATION', 24)
 
 KOBOFORM_PREVIEW_SERVER = os.environ.get('KOBOFORM_PREVIEW_SERVER', 'http://kf.kobotoolbox.org')
-ENKETO_SERVER = os.environ.get('ENKETO_SERVER', 'https://enketo.org')
-ENKETO_PREVIEW_URI = os.environ.get('ENKETO_PREVIEW_URI', '/webform/preview')
+ENKETO_SERVER = os.environ.get('ENKETO_URL') or os.environ.get('ENKETO_SERVER', 'https://enketo.org')
+ENKETO_VERSION= os.environ.get('ENKETO_VERSION', 'Legacy').lower()
+assert ENKETO_VERSION in ['legacy', 'express']
+ENKETO_PREVIEW_URI = os.environ.get('ENKETO_PREVIEW_URI') or 'webform/preview' if ENKETO_VERSION == 'legacy' else '/preview'
 MARKITUP_FILTER = ('markdown.markdown', {'safe_mode': False})
 
 LOGIN_REDIRECT_URL = '/'


### PR DESCRIPTION
…ERSION` (and `ENKETO_API_TOKEN` for KC.).

Tested locally against EE; backwards compatible with Legacy configurations.