### PR TITLE
Do not redirect away from the admin interface

### DIFF
--- a/dkobo/hub/middleware.py
+++ b/dkobo/hub/middleware.py
@@ -33,6 +33,9 @@ class OtherFormBuilderRedirectMiddleware(object):
         ''' Using process_view instead of process_request allows the resolver
         to run and return 404 when appropriate, instead of blindly returning
         302 for all requests '''
+        if request.path_info.startswith('/admin/'):
+            # Never redirect the admin interface
+            return
         preferred_builder = self.THIS_BUILDER
         if not settings.KPI_PREFIX or not settings.DKOBO_PREFIX \
                 or request.user.is_anonymous():


### PR DESCRIPTION
When the user prefers another form builder, their access to the admin interface should not be impeded.