### PR TITLE
Install deps to enable SNI support in `requests`

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -25,3 +25,8 @@ django-ses
 django-digest
 # django-digest depends on python-digest but does not install it automatically
 python-digest
+
+# These packages allow `requests` to support SNI
+pyopenssl
+ndg-httpsclient
+pyasn1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,38 +6,51 @@
 #
 -e git+https://github.com/kobotoolbox/pyxform.git@master#egg=pyxform
 BeautifulSoup==3.2.1
-boto==2.39.0              # via django-ses
-contextlib2==0.5.1        # via raven
-dj-database-url==0.4.0    # via django-toolbelt
+boto==2.42.0              # via django-ses
+cffi==1.8.3               # via cryptography
+contextlib2==0.5.4        # via raven
+cryptography==1.5.2       # via pyopenssl
+dj-database-url==0.4.1    # via django-toolbelt
 dj-static==0.0.6          # via django-toolbelt
-django-appconf==1.0.1     # via django-compressor
-django-compressor==2.0
+django-appconf==1.0.2     # via django-compressor
+django-compressor==2.1
 django-digest==1.13
-django-extensions==1.6.1
-django-guardian==1.4.1
-jsonfield==1.0.3
+django-extensions==1.7.4
+django-guardian==1.4.6
 django-markdown==0.8.4
 django-markitup==2.3.1
-django-registration-redux==1.3
-django-reversion==1.10.1
-django-ses==0.7.0
-django-taggit==0.18.0
+django-registration-redux==1.4
+django-reversion==1.10.2
+django-ses==0.8.1
+django-taggit==0.21.3
 django-toolbelt==0.0.1
-Django==1.8.9
-djangorestframework==3.3.2
-gunicorn==19.4.5
+Django==1.8.15
+djangorestframework==3.4.7
+enum34==1.1.6             # via cryptography
+gunicorn==19.6.0
 hamlpy==0.82.2
+idna==2.1                 # via cryptography
+ipaddress==1.0.17         # via cryptography
+jsonfield==1.0.3
 lxml==2.3.4
 manifesto==0.5
-markdown==2.6.5           # via django-markdown, hamlpy
-psycopg2==2.6.1           # via django-toolbelt
-pygments==2.1             # via hamlpy
+markdown==2.6.7           # via django-markdown, hamlpy
+ndg-httpsclient==0.4.2
+psycopg2==2.6.2           # via django-toolbelt
+pyasn1==0.1.9
+pycparser==2.14           # via cffi
+pygments==2.1.3           # via hamlpy
+pyopenssl==16.1.0
 python-digest==1.7
-raven==5.10.2
+raven==5.27.1
 rcssmin==1.0.6            # via django-compressor
-requests==2.9.1
+requests==2.11.1
 rjsmin==1.0.12            # via django-compressor
-six==1.10.0               # via django-appconf, django-extensions, django-guardian
-static3==0.6.1            # via dj-static
+six==1.10.0               # via cryptography, django-extensions, django-guardian, pyopenssl
+static3==0.7.0            # via dj-static
 xlrd==0.8.0
-xlwt==1.0.0
+xlwt==1.1.2
+
+# The following packages are commented out because they are
+# considered to be unsafe in a requirements file:
+# setuptools                # via cryptography


### PR DESCRIPTION
Also install new point releases of other Python dependencies. Requires `libffi` development package (`libffi-dev` in Debian-world).