### PR TITLE
Upgrade reversion to 2.0.8. Read WARNING below!

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ django-guardian==1.4.6
 django-markdown==0.8.4
 django-markitup==2.3.1
 django-registration-redux==1.4
-django-reversion==1.10.2
+django-reversion==2.0.8
 django-ses==0.8.1
 django-taggit==0.21.3
 django-toolbelt==0.0.1


### PR DESCRIPTION
If your database is large, the migration included in this update of
django-reversion will be slow. For example, on a database with 3.3 million rows
in the `reversion_version` table, the migration takes about 20 minutes. This
can be reduced to around 7 minutes on the same size of database by checking out
commit e822bb1 (from https://github.com/etianen/django-reversion/pull/611).