### PR TITLE
When KPI configured, disable dkobo registrations

### DIFF
--- a/dkobo/koboform/views/__init__.py
+++ b/dkobo/koboform/views/__init__.py
@@ -1,6 +1,12 @@
 import json
+import logging
 
-from django.shortcuts import render_to_response, HttpResponse, HttpResponseRedirect
+from django.shortcuts import (
+    render_to_response,
+    HttpResponse,
+    HttpResponseRedirect,
+    redirect
+)
 from django.template import RequestContext
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.contrib.auth.decorators import login_required
@@ -55,3 +61,11 @@ def kobocat_redirect(request, path=''):
         return HttpResponseRedirect(url)
     else:
         raise NotImplementedError("kobocat integration is not enabled. [No settings.KOBOCAT_URL]")
+
+def registration_disallowed(request):
+    if getattr(settings, 'REGISTRATION_URL', False):
+        return HttpResponseRedirect(settings.REGISTRATION_URL)
+    else:
+        logging.warning("`REGISTRATION_CLOSED == True` but no "
+                        "`REGISTRATION_URL` configured")
+        return redirect('spa')

--- a/dkobo/urls.py
+++ b/dkobo/urls.py
@@ -30,6 +30,9 @@ urlpatterns = patterns(
     url(r'^accounts/logout/', 'django.contrib.auth.views.logout', {'next_page': '/'}),
     url(r'^accounts/register/$', RegistrationView.as_view(
         form_class=RegistrationForm), name='registration_register'),
+    url(r'^accounts/register/closed/',
+        'dkobo.koboform.views.registration_disallowed',
+        name='registration_disallowed'),
     url(r'^accounts/', include('registration.backends.default.urls')),
     url(r'^account/', include('django.contrib.auth.urls')),
     # fallback on koboform app-specific urls:


### PR DESCRIPTION
...and redirect dkobo's registration view to KPI's. If any user has registered
before this change but activates afterwards, their form builder preference will
be set to KPI. Fixes kobotoolbox/tasks#112.